### PR TITLE
[Bug] Download Link Update

### DIFF
--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -22,7 +22,7 @@ incubator_name: incubator-systemml
 incubator_slash_name: incubator/systemml
 description: Apache SystemML is a distributed and declarative machine learning platform.
 
-download: /download.html
+download: /download
 
 dev_list: dev@systemml.incubator.apache.org
 dev_list_subscribe: dev-subscribe@systemml.incubator.apache.org

--- a/site/history.md
+++ b/site/history.md
@@ -30,7 +30,7 @@ limitations under the License.
 For a full list of releases, see
 <a href="https://github.com/apache/{{ site.data.project.incubator_slash_name }}/releases">github</a>.
 Downloads are available on the
-[downloads page]({{ site.baseurl }}/download.html).
+[downloads page]({{ site.baseurl }}/download).
 
 ## <a href="https://github.com/apache/{{ site.data.project.incubator_slash_name }}/releases/tag/{{ site.data.project.unix_name }}-0.2.0">0.2.0</a> / 2015-11-10
 {: #v0-2-0}


### PR DESCRIPTION
The download-page is actually a Markdown file.
with `.html` it will point to 404